### PR TITLE
Add support for paths in CLI add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "inquire",
  "iso_currency",
  "log",
+ "pathdiff",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -706,6 +707,12 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "petgraph"

--- a/firm_cli/Cargo.toml
+++ b/firm_cli/Cargo.toml
@@ -29,3 +29,4 @@ convert_case = "0.8.0"
 chrono = "0.4.41"
 rust_decimal = { version = "1.37", features = ["serde-with-str"] }
 iso_currency = { version = "0.5", features = ["with-serde", "iterator"] }
+pathdiff = "0.2.3"


### PR DESCRIPTION
This adds the path prompt for CLI add command. We provide autocomplete for paths in the workspace, and then transform it to a relative path to where the source file will be stored.