### PR TITLE
Update README.md: add installation steps avoiding sudo on unknown scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Firm CLI is available to download via [Github Releases](https://github.com/4
 ### Linux and macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/42futures/firm/main/install.sh
+curl -fsSL https://raw.githubusercontent.com/42futures/firm/main/install.sh | sudo bash
 ```
 
 If you don't feel confident running it with `sudo` follow those steps:


### PR DESCRIPTION
@danielrothmann With this PR, I’m suggesting an alternative way to start the project without running a remote script using the `sudo` for linux and macOS. Feel free to decline or modify it as you see fit.