### PR TITLE
Schema support in get command

### DIFF
--- a/docs/src/reference/cli-reference.md
+++ b/docs/src/reference/cli-reference.md
@@ -84,22 +84,27 @@ This:
 
 ### get
 
-Get details of a specific entity.
+Get details of a specific entity or schema.
 
 ```bash
-firm get <entity_type> <entity_id>
+firm get <target_type> <target_id>
 ```
 
 **Arguments:**
-- `entity_type` - The type of entity (e.g., `person`, `organization`, `task`)
-- `entity_id` - The ID of the entity (e.g., `john_doe`)
+- `target_type` - Entity type (e.g., `person`, `organization`, `task`) or `schema`
+- `target_id` - Entity ID (e.g., `john_doe`) or schema name (e.g., `project`)
 
 **Examples:**
 
 ```bash
+# Get an entity
 firm get person john_doe
 firm get organization acme_corp
 firm get task design_homepage
+
+# Get a schema
+firm get schema project
+firm get schema person
 ```
 
 ### list

--- a/firm_cli/AGENTS.md.template
+++ b/firm_cli/AGENTS.md.template
@@ -41,12 +41,19 @@ firm query <query_string>
 #### `firm build`
 Validate the workspace and build the entity graph.
 
-#### `firm get <entity_type> <entity_id>`
-Get details for a specific entity.
+#### `firm get <target_type> <target_id>`
+Get details for a specific entity or schema.
 
-Example: `firm get contact john_at_acme`
+Examples:
+```bash
+# Get an entity
+firm get contact john_at_acme
 
-#### `firm list <entity_type>`
+# Get a schema
+firm get schema project
+```
+
+#### `firm list <target_type>`
 List all entities of a type. Use `firm list schema` to see available schemas.
 
 Example: `firm list task`

--- a/firm_cli/src/cli.rs
+++ b/firm_cli/src/cli.rs
@@ -36,12 +36,12 @@ pub enum FirmCliCommand {
     Init,
     /// Build workspace and entity graph.
     Build,
-    /// Get an entity by ID.
+    /// Get an entity or schema.
     Get {
-        /// Entity type (e.g. person, organization or project)
-        entity_type: String,
-        /// Entity ID (e.g. john_doe)
-        entity_id: String,
+        /// Entity type (e.g. person, organization) or "schema"
+        target_type: String,
+        /// Entity ID (e.g. john_doe) or schema name (e.g. project)
+        target_id: String,
     },
     /// List entities of a type, or list all schemas.
     List {

--- a/firm_cli/src/commands/get.rs
+++ b/firm_cli/src/commands/get.rs
@@ -5,11 +5,25 @@ use std::path::PathBuf;
 use super::{build_workspace, load_workspace_files};
 use crate::errors::CliError;
 use crate::files::load_current_graph;
-use crate::query::CliDirection;
 use crate::ui::{self, OutputFormat};
 
-/// Gets an entity by ID from the current workspace entity graph.
-pub fn get_entity_by_id(
+/// Gets an entity or schema by type and ID/name.
+pub fn get_item(
+    workspace_path: &PathBuf,
+    target_type: String,
+    target_id: String,
+    output_format: OutputFormat,
+) -> Result<(), CliError> {
+    // Special case: if target_type is "schema", get schema instead of entity
+    if target_type == "schema" {
+        return get_schema(workspace_path, target_id, output_format);
+    }
+
+    get_entity(workspace_path, target_type, target_id, output_format)
+}
+
+/// Gets a single entity by type and ID.
+fn get_entity(
     workspace_path: &PathBuf,
     entity_type: String,
     entity_id: String,
@@ -22,7 +36,7 @@ pub fn get_entity_by_id(
     match graph.get_entity(&id) {
         Some(entity) => {
             ui::success(&format!(
-                "Found '{}' entity with ID '{}'",
+                "Found '{}' entity with ID '{}'",
                 entity_type, entity_id
             ));
 
@@ -30,106 +44,48 @@ pub fn get_entity_by_id(
                 ui::OutputFormat::Pretty => ui::pretty_output_entity_single(entity),
                 ui::OutputFormat::Json => ui::json_output(entity),
             }
-        }
-        None => {
-            ui::error(&format!(
-                "Couldn't find '{}' entity with ID '{}'",
-                entity_type, entity_id
-            ));
-
-            return Err(CliError::QueryError);
-        }
-    }
-
-    Ok(())
-}
-
-/// Gets relatives for an entity by ID from the current workspace entity graph.
-pub fn get_related_entities(
-    workspace_path: &PathBuf,
-    entity_type: String,
-    entity_id: String,
-    direction: Option<CliDirection>,
-    output_format: OutputFormat,
-) -> Result<(), CliError> {
-    ui::header("Getting related entities");
-    let graph = load_current_graph(&workspace_path)?;
-
-    let id = compose_entity_id(&entity_type, &entity_id);
-    match graph.get_related(&id, direction.clone().map(|d| d.into())) {
-        Some(entities) => {
-            let direction_text = match direction {
-                Some(CliDirection::To) => "references to",
-                Some(CliDirection::From) => "references from",
-                None => "relationships for",
-            };
-
-            ui::success(&format!(
-                "Found {} {} '{}' entity with ID '{}'",
-                entities.len(),
-                direction_text,
-                entity_type,
-                entity_id
-            ));
-
-            match output_format {
-                OutputFormat::Pretty => ui::pretty_output_entity_list(&entities),
-                OutputFormat::Json => ui::json_output(&entities),
-            }
-
             Ok(())
         }
         None => {
             ui::error(&format!(
-                "Couldn't find '{}' entity with ID '{}'",
+                "Couldn't find '{}' entity with ID '{}'",
                 entity_type, entity_id
             ));
-
             Err(CliError::QueryError)
         }
     }
 }
 
-/// Lists entities of a given type in the workspace.
-pub fn list_entities_by_type(
+/// Gets a single schema by name.
+fn get_schema(
     workspace_path: &PathBuf,
-    entity_type: String,
+    schema_name: String,
     output_format: OutputFormat,
 ) -> Result<(), CliError> {
-    ui::header("Listing entities by type");
-    let graph = load_current_graph(&workspace_path)?;
-
-    let entities = graph.list_by_type(&entity_type.as_str().into());
-    ui::success(&format!(
-        "Found {} entities with type '{}'",
-        entities.len(),
-        entity_type,
-    ));
-
-    match output_format {
-        OutputFormat::Pretty => ui::pretty_output_entity_list(&entities),
-        OutputFormat::Json => ui::json_output(&entities),
-    }
-
-    Ok(())
-}
-
-/// Lists schemas in the workspace.
-/// This is a special case for the CLI list action where a type of "schema" is provided.
-pub fn list_schemas(workspace_path: &PathBuf, output_format: OutputFormat) -> Result<(), CliError> {
-    ui::header("Listing schemas");
+    ui::header("Getting schema");
     let mut workspace = Workspace::new();
     load_workspace_files(&workspace_path, &mut workspace).map_err(|_| CliError::BuildError)?;
     let build = build_workspace(workspace).map_err(|_| CliError::BuildError)?;
 
-    ui::success(&format!(
-        "Found {} schemas for this workspace",
-        build.schemas.len()
-    ));
+    // Find the schema by name
+    let schema = build
+        .schemas
+        .iter()
+        .find(|s| s.entity_type.as_str() == schema_name);
 
-    match output_format {
-        OutputFormat::Pretty => ui::pretty_output_schema_list(&build.schemas.iter().collect()),
-        OutputFormat::Json => ui::json_output(&build.schemas),
+    match schema {
+        Some(schema) => {
+            ui::success(&format!("Found schema '{}'", schema_name));
+
+            match output_format {
+                OutputFormat::Pretty => ui::pretty_output_schema_single(schema),
+                OutputFormat::Json => ui::json_output(schema),
+            }
+            Ok(())
+        }
+        None => {
+            ui::error(&format!("Schema '{}' not found in workspace", schema_name));
+            Err(CliError::QueryError)
+        }
     }
-    Ok(())
 }

--- a/firm_cli/src/commands/list.rs
+++ b/firm_cli/src/commands/list.rs
@@ -1,0 +1,64 @@
+use firm_lang::workspace::Workspace;
+use std::path::PathBuf;
+
+use super::{build_workspace, load_workspace_files};
+use crate::errors::CliError;
+use crate::files::load_current_graph;
+use crate::ui::{self, OutputFormat};
+
+/// Lists entities of a type or all schemas.
+pub fn list_items(
+    workspace_path: &PathBuf,
+    target_type: String,
+    output_format: OutputFormat,
+) -> Result<(), CliError> {
+    // Special case: if target_type is "schema", list all schemas instead of entities
+    if target_type == "schema" {
+        return list_schemas(workspace_path, output_format);
+    }
+
+    list_entities(workspace_path, target_type, output_format)
+}
+
+/// Lists entities of a given type in the workspace.
+fn list_entities(
+    workspace_path: &PathBuf,
+    entity_type: String,
+    output_format: OutputFormat,
+) -> Result<(), CliError> {
+    ui::header("Listing entities by type");
+    let graph = load_current_graph(&workspace_path)?;
+
+    let entities = graph.list_by_type(&entity_type.as_str().into());
+    ui::success(&format!(
+        "Found {} entities with type '{}'",
+        entities.len(),
+        entity_type,
+    ));
+
+    match output_format {
+        OutputFormat::Pretty => ui::pretty_output_entity_list(&entities),
+        OutputFormat::Json => ui::json_output(&entities),
+    }
+
+    Ok(())
+}
+
+/// Lists all schemas in the workspace.
+fn list_schemas(workspace_path: &PathBuf, output_format: OutputFormat) -> Result<(), CliError> {
+    ui::header("Listing schemas");
+    let mut workspace = Workspace::new();
+    load_workspace_files(&workspace_path, &mut workspace).map_err(|_| CliError::BuildError)?;
+    let build = build_workspace(workspace).map_err(|_| CliError::BuildError)?;
+
+    ui::success(&format!(
+        "Found {} schemas for this workspace",
+        build.schemas.len()
+    ));
+
+    match output_format {
+        OutputFormat::Pretty => ui::pretty_output_schema_list(&build.schemas.iter().collect()),
+        OutputFormat::Json => ui::json_output(&build.schemas),
+    }
+    Ok(())
+}

--- a/firm_cli/src/commands/mod.rs
+++ b/firm_cli/src/commands/mod.rs
@@ -3,12 +3,16 @@ mod build;
 mod field_prompt;
 mod get;
 mod init;
+mod list;
 mod query;
+mod related;
 mod source;
 
 pub use add::add_entity;
 pub use build::{build_and_save_graph, build_workspace, load_workspace_files};
-pub use get::{get_entity_by_id, get_related_entities, list_entities_by_type, list_schemas};
+pub use get::get_item;
 pub use init::init_workspace;
+pub use list::list_items;
 pub use query::query_entities;
-pub use source::find_entity_source;
+pub use related::get_related_entities;
+pub use source::find_item_source;

--- a/firm_cli/src/commands/related.rs
+++ b/firm_cli/src/commands/related.rs
@@ -1,0 +1,53 @@
+use firm_core::compose_entity_id;
+use std::path::PathBuf;
+
+use crate::errors::CliError;
+use crate::files::load_current_graph;
+use crate::query::CliDirection;
+use crate::ui::{self, OutputFormat};
+
+/// Gets entities related to a specific entity.
+pub fn get_related_entities(
+    workspace_path: &PathBuf,
+    entity_type: String,
+    entity_id: String,
+    direction: Option<CliDirection>,
+    output_format: OutputFormat,
+) -> Result<(), CliError> {
+    ui::header("Getting related entities");
+    let graph = load_current_graph(&workspace_path)?;
+
+    let id = compose_entity_id(&entity_type, &entity_id);
+    match graph.get_related(&id, direction.clone().map(|d| d.into())) {
+        Some(entities) => {
+            let direction_text = match direction {
+                Some(CliDirection::To) => "references to",
+                Some(CliDirection::From) => "references from",
+                None => "relationships for",
+            };
+
+            ui::success(&format!(
+                "Found {} {} '{}' entity with ID '{}'",
+                entities.len(),
+                direction_text,
+                entity_type,
+                entity_id
+            ));
+
+            match output_format {
+                OutputFormat::Pretty => ui::pretty_output_entity_list(&entities),
+                OutputFormat::Json => ui::json_output(&entities),
+            }
+
+            Ok(())
+        }
+        None => {
+            ui::error(&format!(
+                "Couldn't find '{}' entity with ID '{}'",
+                entity_type, entity_id
+            ));
+
+            Err(CliError::QueryError)
+        }
+    }
+}

--- a/firm_cli/src/commands/source.rs
+++ b/firm_cli/src/commands/source.rs
@@ -6,7 +6,7 @@ use crate::errors::CliError;
 use crate::ui::{self, OutputFormat};
 
 /// Finds the source file for an entity or schema by its type and ID/name.
-pub fn find_entity_source(
+pub fn find_item_source(
     workspace_path: &PathBuf,
     target_type: String,
     target_id: String,

--- a/firm_cli/src/main.rs
+++ b/firm_cli/src/main.rs
@@ -53,15 +53,11 @@ fn main() -> ExitCode {
         FirmCliCommand::Init => commands::init_workspace(&workspace_path),
         FirmCliCommand::Build => build_and_save_graph(&workspace_path),
         FirmCliCommand::Get {
-            entity_type,
-            entity_id,
-        } => commands::get_entity_by_id(&workspace_path, entity_type, entity_id, cli.format),
+            target_type,
+            target_id,
+        } => commands::get_item(&workspace_path, target_type, target_id, cli.format),
         FirmCliCommand::List { target_type } => {
-            if target_type == "schema" {
-                commands::list_schemas(&workspace_path, cli.format)
-            } else {
-                commands::list_entities_by_type(&workspace_path, target_type, cli.format)
-            }
+            commands::list_items(&workspace_path, target_type, cli.format)
         }
         FirmCliCommand::Related {
             entity_type,
@@ -97,7 +93,7 @@ fn main() -> ExitCode {
         FirmCliCommand::Source {
             target_type,
             target_id,
-        } => commands::find_entity_source(&workspace_path, target_type, target_id, cli.format),
+        } => commands::find_item_source(&workspace_path, target_type, target_id, cli.format),
     };
 
     result.map_or(ExitCode::FAILURE, |_| ExitCode::SUCCESS)


### PR DESCRIPTION
This PR adds support for `firm get schema {schema_name}` which now seems expected based on functionality in `firm list` and `firm source`.

Also, a lot of access commands were clumping together in get.rs, so I reorganised them in a way where one file corresponds to one command.