### PR TITLE
CLI list output IDs

### DIFF
--- a/firm_cli/src/commands/list.rs
+++ b/firm_cli/src/commands/list.rs
@@ -20,7 +20,7 @@ pub fn list_items(
     list_entities(workspace_path, target_type, output_format)
 }
 
-/// Lists entities of a given type in the workspace.
+/// Lists entity IDs of a given type in the workspace.
 fn list_entities(
     workspace_path: &PathBuf,
     entity_type: String,
@@ -30,35 +30,34 @@ fn list_entities(
     let graph = load_current_graph(workspace_path)?;
 
     let entities = graph.list_by_type(&entity_type.as_str().into());
+    let ids: Vec<&str> = entities.iter().map(|e| e.id.as_str()).collect();
+
     ui::success(&format!(
         "Found {} entities with type '{}'",
-        entities.len(),
+        ids.len(),
         entity_type,
     ));
 
-    match output_format {
-        OutputFormat::Pretty => ui::pretty_output_entity_list(&entities),
-        OutputFormat::Json => ui::json_output(&entities),
-    }
+    ui::list_output(&ids, output_format);
 
     Ok(())
 }
 
-/// Lists all schemas in the workspace.
+/// Lists all schema names in the workspace.
 fn list_schemas(workspace_path: &PathBuf, output_format: OutputFormat) -> Result<(), CliError> {
     ui::header("Listing schemas");
     let mut workspace = Workspace::new();
     load_workspace_files(workspace_path, &mut workspace).map_err(|_| CliError::BuildError)?;
     let build = build_workspace(workspace).map_err(|_| CliError::BuildError)?;
 
-    ui::success(&format!(
-        "Found {} schemas for this workspace",
-        build.schemas.len()
-    ));
+    let names: Vec<&str> = build
+        .schemas
+        .iter()
+        .map(|s| s.entity_type.as_str())
+        .collect();
 
-    match output_format {
-        OutputFormat::Pretty => ui::pretty_output_schema_list(&build.schemas.iter().collect()),
-        OutputFormat::Json => ui::json_output(&build.schemas),
-    }
+    ui::success(&format!("Found {} schemas for this workspace", names.len()));
+
+    ui::list_output(&names, output_format);
     Ok(())
 }

--- a/firm_cli/src/ui.rs
+++ b/firm_cli/src/ui.rs
@@ -78,8 +78,7 @@ pub fn error_with_details(main_msg: &str, details: &str) {
 }
 
 /// Selects the output format used by the CLI.
-#[derive(Clone, Debug, ValueEnum, PartialEq)]
-#[derive(Default)]
+#[derive(Clone, Debug, ValueEnum, PartialEq, Default)]
 pub enum OutputFormat {
     #[default]
     Pretty,
@@ -94,7 +93,6 @@ impl fmt::Display for OutputFormat {
         }
     }
 }
-
 
 /// Outputs a single entity in pretty format.
 pub fn pretty_output_entity_single(entity: &Entity) {
@@ -118,22 +116,22 @@ pub fn pretty_output_schema_single(schema: &EntitySchema) {
     println!("\n{}", schema);
 }
 
-/// Outputs a list of entity schemas in pretty format.
-pub fn pretty_output_schema_list(schemas: &Vec<&EntitySchema>) {
-    for (i, schema) in schemas.iter().enumerate() {
-        pretty_output_schema_single(schema);
-
-        // Add a separator after each entity, except for the last one.
-        if i < schemas.len() - 1 {
-            println!("---------------------------------------");
-        }
-    }
-}
-
 /// Outputs a serde-serializable object in json format.
 pub fn json_output<T: serde::Serialize>(data: &T) {
     if let Ok(json) = serde_json::to_string_pretty(data) {
         println!("{}", json);
+    }
+}
+
+/// Outputs a list of strings (one per line for pretty, array for JSON).
+pub fn list_output(items: &[&str], format: OutputFormat) {
+    match format {
+        OutputFormat::Pretty => {
+            for item in items {
+                println!("{}", item);
+            }
+        }
+        OutputFormat::Json => json_output(&items),
     }
 }
 


### PR DESCRIPTION
While working on the MCP server, I realised that "list" in its original form had lost some utility.

Since we now have "query" for searches that outputs details of the result set, "list" makes more sense as a way to quickly get an overview of entities or schemas. You can then subsequently use "get" for details, or "query" to search where you can configure your own limits.

This PR makes the CLI list command consistent with the MCP list tool, by outputting only IDs of entities or names of schemas. I feel this fits better into the workflow.