### PR TITLE
feat(cli): support environment variables for global options

### DIFF
--- a/docs/src/reference/cli-reference.md
+++ b/docs/src/reference/cli-reference.md
@@ -4,7 +4,13 @@ Complete reference for the Firm command-line interface.
 
 ## Global options
 
-These options apply to all commands:
+These options apply to all commands.
+
+Each global option can be set via a command-line flag, an environment variable, or left to its default. They are evaluated in the following order (highest priority first):
+
+1. **Command-line flag** — always takes precedence
+2. **Environment variable** — used when no flag is provided
+3. **Default value** — used when neither flag nor environment variable is set
 
 ### --workspace (-w)
 
@@ -17,6 +23,8 @@ firm -w /absolute/path/to/workspace get person john_doe
 
 Default: Current working directory
 
+Environment variable: `FIRM_WORKSPACE`
+
 ### --cached (-c)
 
 Use the cached entity graph instead of rebuilding:
@@ -28,6 +36,8 @@ firm -c query 'from task | where is_completed == false'
 
 Default: false (graph is rebuilt before each command)
 
+Environment variable: `FIRM_CACHED`
+
 ### --verbose (-v)
 
 Enable verbose logging output:
@@ -36,6 +46,8 @@ Enable verbose logging output:
 firm --verbose build
 firm -v list task
 ```
+
+Environment variable: `FIRM_VERBOSE`
 
 ### --format (-f)
 
@@ -49,6 +61,8 @@ firm -f pretty get person john_doe
 Options:
 - `pretty` (default) - Human-readable formatted output
 - `json` - JSON output for programmatic use
+
+Environment variable: `FIRM_FORMAT`
 
 ## Commands
 

--- a/firm_cli/Cargo.toml
+++ b/firm_cli/Cargo.toml
@@ -17,7 +17,7 @@ firm_mcp = { path = "../firm_mcp" }
 
 tokio = { version = "1", features = ["rt-multi-thread"] }
 
-clap = { version = "4.5.42", features = ["derive"] }
+clap = { version = "4.5.42", features = ["derive", "env"] }
 console = "0.16.0"
 indicatif = "0.18.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/firm_cli/src/cli.rs
+++ b/firm_cli/src/cli.rs
@@ -10,19 +10,19 @@ use super::ui::OutputFormat;
 #[command(version, about = "Firm CLI: Work management in the terminal.")]
 pub struct FirmCli {
     /// Path to firm workspace directory.
-    #[arg(short, long, global = true)]
+    #[arg(short, long, global = true, env = "FIRM_WORKSPACE")]
     pub workspace: Option<PathBuf>,
 
     /// Use cached firm graph?
-    #[arg(short, long, global = true)]
+    #[arg(short, long, global = true, env = "FIRM_CACHED")]
     pub cached: bool,
 
     /// Enable verbose output?
-    #[arg(short, long, global = true)]
+    #[arg(short, long, global = true, env = "FIRM_VERBOSE")]
     pub verbose: bool,
 
     /// Output format
-    #[arg(short, long, global = true, default_value_t = OutputFormat::default())]
+    #[arg(short, long, global = true, default_value_t = OutputFormat::default(), env = "FIRM_FORMAT")]
     pub format: OutputFormat,
 
     #[command(subcommand)]


### PR DESCRIPTION
## Summary

This PR addresses issue #50.

- Add environment variable support for all global CLI flags: `FIRM_WORKSPACE`, `FIRM_CACHED`, `FIRM_VERBOSE`, `FIRM_FORMAT`
- Enable clap `env` feature and add `env` attributes to each global arg
- Document environment variables and their precedence (flag > env var > default) in CLI reference

## Test plan

- [ ] Verify `FIRM_WORKSPACE=/path firm list task` uses the specified workspace
- [ ] Verify `FIRM_FORMAT=json firm list task` outputs JSON
- [ ] Verify CLI flags override environment variables when both are set
- [ ] Verify `firm --help` shows environment variable names for each global option
