### PR TITLE
FFI bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,10 +82,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
+]
 
 [[package]]
 name = "assert_matches"
@@ -115,6 +163,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -205,6 +262,38 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "cc"
@@ -495,6 +584,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "firm_ffi"
+version = "0.5.0"
+dependencies = [
+ "chrono",
+ "firm_core",
+ "firm_lang",
+ "iso_currency",
+ "rust_decimal",
+ "thiserror",
+ "uniffi",
+]
+
+[[package]]
 name = "firm_lang"
 version = "0.5.0"
 dependencies = [
@@ -543,6 +645,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "funty"
@@ -682,6 +793,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +877,8 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -890,12 +1020,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "newline-converter"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -936,6 +1082,12 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1004,6 +1156,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1257,6 +1415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,10 +1496,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1393,6 +1587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,10 +1619,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
@@ -1496,6 +1717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1796,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1839,12 @@ checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
@@ -1690,6 +1941,139 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "uniffi"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "indexmap",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b78fd9271a4c2e85bd2c266c5a9ede1fac676eb39fd77f636c27eaf67426fd5f"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.106",
+ "toml",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
 
 [[package]]
 name = "unit-prefix"
@@ -1810,6 +2194,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["firm_core", "firm_lang", "firm_mcp", "firm_cli"]
+members = ["firm_core", "firm_lang", "firm_mcp", "firm_cli", "firm_ffi"]
 resolver = "3"

--- a/docs/src/library/architecture.md
+++ b/docs/src/library/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Firm is organized as a Rust workspace with three crates, each with a specific responsibility.
+Firm is organized as a Rust workspace with five crates, each with a specific responsibility.
 
 ## Crate overview
 
@@ -8,7 +8,9 @@ Firm is organized as a Rust workspace with three crates, each with a specific re
 firm/
 ├── firm_core/     - Core data structures and graph operations
 ├── firm_lang/     - DSL parsing and generation
-└── firm_cli/      - Command-line interface
+├── firm_cli/      - Command-line interface
+├── firm_mcp/      - MCP server for AI assistants
+└── firm_ffi/      - UniFFI bindings for embedding in other apps
 ```
 
 ## firm_core
@@ -92,3 +94,27 @@ firm init
 firm add --type person --id john
 firm query 'from person | where name == "John"'
 ```
+
+## firm_mcp
+
+MCP (Model Context Protocol) server exposing workspace operations as tools for AI assistants.
+
+**Responsibilities:**
+- Expose query, entity access, and source operations as MCP tools
+- Schema-aware entity creation from JSON
+- Source file read/write/search operations
+
+## firm_ffi
+
+UniFFI-based foreign function interface for embedding Firm in other apps.
+
+**Responsibilities:**
+- Exposes `FirmSession` as an opaque handle for loading sources, building, and querying
+- Typed FFI representations of entities, fields, and query results
+- Bidirectional conversion between FFI types and core types
+
+**Key types:**
+- `FirmSession` - Opaque session managing a workspace and entity graph
+- `FirmEntity` - Entity with typed fields
+- `FirmFieldValue` - Enum mirroring `FieldValue` with FFI-safe types
+- `FirmQueryResult` - Query result (entities or aggregation)

--- a/firm_ffi/Cargo.toml
+++ b/firm_ffi/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "firm_ffi"
+version = "0.5.0"
+edition = "2024"
+license = "AGPL-3.0"
+
+[lib]
+crate-type = ["staticlib", "cdylib", "lib"]
+
+[dependencies]
+firm_core = { path = "../firm_core" }
+firm_lang = { path = "../firm_lang" }
+uniffi = { version = "0.31", features = ["cli"] }
+thiserror = "2"
+chrono = "0.4.43"
+rust_decimal = "1.40.0"
+iso_currency = "0.5.3"
+
+[build-dependencies]
+uniffi = { version = "0.31", features = ["build"] }
+
+[dev-dependencies]
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "uniffi-bindgen.rs"

--- a/firm_ffi/build-ios.sh
+++ b/firm_ffi/build-ios.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build firm_ffi for iOS targets and generate Swift bindings
+
+echo "Building for iOS device (aarch64-apple-ios)..."
+cargo build -p firm_ffi --release --target aarch64-apple-ios
+
+echo "Building for iOS simulator (aarch64-apple-ios-sim)..."
+cargo build -p firm_ffi --release --target aarch64-apple-ios-sim
+
+echo "Generating Swift bindings..."
+cargo run -p firm_ffi --bin uniffi-bindgen generate \
+    --library target/release/libfirm_ffi.dylib \
+    --language swift \
+    --out-dir ./firm_ffi/generated
+
+echo "Done. Swift bindings are in firm_ffi/generated/"

--- a/firm_ffi/src/lib.rs
+++ b/firm_ffi/src/lib.rs
@@ -1,0 +1,235 @@
+uniffi::setup_scaffolding!();
+
+mod types;
+
+pub use types::{FirmDirection, FirmEntity, FirmField, FirmFieldValue, FirmQueryResult};
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use firm_core::graph::{EntityGraph, Query, QueryResult};
+use firm_core::{Entity, EntityType, compose_entity_id};
+use firm_lang::generate::generate_dsl;
+use firm_lang::parser::query::parse_query;
+use firm_lang::workspace::{Workspace, WorkspaceBuild};
+
+/// Errors from the FFI layer.
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum FirmError {
+    #[error("Parse error: {message}")]
+    ParseError { message: String },
+    #[error("Build error: {message}")]
+    BuildError { message: String },
+    #[error("Query error: {message}")]
+    QueryError { message: String },
+    #[error("Not built: call build() first")]
+    NotBuilt,
+    #[error("{message}")]
+    Other { message: String },
+}
+
+/// Opaque handle to a Firm workspace with built graph.
+#[derive(uniffi::Object)]
+pub struct FirmSession {
+    inner: Mutex<SessionInner>,
+}
+
+struct SessionInner {
+    workspace: Workspace,
+    build: Option<WorkspaceBuild>,
+    graph: Option<EntityGraph>,
+}
+
+impl Default for FirmSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[uniffi::export]
+impl FirmSession {
+    /// Create a new empty session.
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(SessionInner {
+                workspace: Workspace::new(),
+                build: None,
+                graph: None,
+            }),
+        }
+    }
+
+    /// Load .firm source text with a virtual path.
+    pub fn load_source(&self, content: String, path: String) -> Result<(), FirmError> {
+        let mut inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        inner
+            .workspace
+            .load_string(content, PathBuf::from(&path))
+            .map_err(|e| FirmError::ParseError {
+                message: e.to_string(),
+            })?;
+        // Invalidate previous build
+        inner.build = None;
+        inner.graph = None;
+        Ok(())
+    }
+
+    /// Parse and validate all loaded sources, build entity graph.
+    pub fn build(&self) -> Result<(), FirmError> {
+        let mut inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        let workspace_build =
+            inner
+                .workspace
+                .build()
+                .map_err(|e| FirmError::BuildError {
+                    message: e.to_string(),
+                })?;
+
+        let mut graph = EntityGraph::new();
+        graph
+            .add_entities(workspace_build.entities.clone())
+            .map_err(|e| FirmError::BuildError {
+                message: format!("{:?}", e),
+            })?;
+        graph.build();
+
+        inner.build = Some(workspace_build);
+        inner.graph = Some(graph);
+        Ok(())
+    }
+
+    /// Execute a Firm query string.
+    pub fn query(&self, query_string: String) -> Result<FirmQueryResult, FirmError> {
+        let inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        let graph = inner.graph.as_ref().ok_or(FirmError::NotBuilt)?;
+
+        let parsed_query = parse_query(&query_string).map_err(|e| FirmError::QueryError {
+            message: format!("Failed to parse query: {}", e),
+        })?;
+
+        let query: Query = parsed_query.try_into().map_err(
+            |e: firm_lang::convert::to_query::QueryConversionError| FirmError::QueryError {
+                message: format!("Failed to convert query: {}", e),
+            },
+        )?;
+
+        let result = query.execute(graph).map_err(|e| FirmError::QueryError {
+            message: format!("Query execution failed: {}", e),
+        })?;
+
+        match result {
+            QueryResult::Entities(entities) => Ok(FirmQueryResult::Entities {
+                entities: entities.iter().map(|e| FirmEntity::from(*e)).collect(),
+            }),
+            QueryResult::Aggregation(agg) => Ok(FirmQueryResult::Aggregation {
+                value: agg.to_string(),
+            }),
+        }
+    }
+
+    /// Get an entity by type and ID.
+    pub fn get_entity(
+        &self,
+        entity_type: String,
+        id: String,
+    ) -> Result<Option<FirmEntity>, FirmError> {
+        let inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        let graph = inner.graph.as_ref().ok_or(FirmError::NotBuilt)?;
+
+        let composite_id = compose_entity_id(&entity_type, &id);
+        Ok(graph.get_entity(&composite_id).map(FirmEntity::from))
+    }
+
+    /// List entity IDs for a given type.
+    pub fn list_entities(&self, entity_type: String) -> Result<Vec<String>, FirmError> {
+        let inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        let graph = inner.graph.as_ref().ok_or(FirmError::NotBuilt)?;
+
+        let et = EntityType::new(&entity_type);
+        let entities = graph.list_by_type(&et);
+        Ok(entities.iter().map(|e| e.id.to_string()).collect())
+    }
+
+    /// List all schema type names.
+    pub fn list_schemas(&self) -> Result<Vec<String>, FirmError> {
+        let inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        let build = inner.build.as_ref().ok_or(FirmError::NotBuilt)?;
+
+        Ok(build
+            .schemas
+            .iter()
+            .map(|s| s.entity_type.to_string())
+            .collect())
+    }
+
+    /// Get related entities.
+    pub fn get_related(
+        &self,
+        entity_type: String,
+        id: String,
+        direction: FirmDirection,
+    ) -> Result<Vec<FirmEntity>, FirmError> {
+        let inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        let graph = inner.graph.as_ref().ok_or(FirmError::NotBuilt)?;
+
+        let composite_id = compose_entity_id(&entity_type, &id);
+        let dir = match direction {
+            FirmDirection::Outgoing => Some(firm_core::graph::Direction::Outgoing),
+            FirmDirection::Incoming => Some(firm_core::graph::Direction::Incoming),
+            FirmDirection::Both => None,
+        };
+
+        match graph.get_related(&composite_id, dir) {
+            Some(entities) => Ok(entities.iter().map(|e| FirmEntity::from(*e)).collect()),
+            None => Ok(vec![]),
+        }
+    }
+
+    /// Generate .firm DSL text for an entity.
+    pub fn generate_entity_dsl(&self, entity: FirmEntity) -> Result<String, FirmError> {
+        let core_entity =
+            Entity::try_from(&entity).map_err(|e| FirmError::Other { message: e })?;
+        Ok(generate_dsl(&[core_entity]))
+    }
+
+    /// Find the virtual path containing a given entity.
+    pub fn find_entity_source(
+        &self,
+        entity_type: String,
+        id: String,
+    ) -> Result<Option<String>, FirmError> {
+        let inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        Ok(inner
+            .workspace
+            .find_entity_source(&entity_type, &id)
+            .map(|p| p.to_string_lossy().into_owned()))
+    }
+
+    /// Get the loaded source content for a virtual path.
+    pub fn get_source(&self, path: String) -> Result<Option<String>, FirmError> {
+        let inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        Ok(inner
+            .workspace
+            .get_source(&PathBuf::from(&path))
+            .map(|s| s.to_string()))
+    }
+}

--- a/firm_ffi/src/lib.rs
+++ b/firm_ffi/src/lib.rs
@@ -2,7 +2,10 @@ uniffi::setup_scaffolding!();
 
 mod types;
 
-pub use types::{FirmDirection, FirmEntity, FirmField, FirmFieldValue, FirmQueryResult};
+pub use types::{
+    FirmDirection, FirmEntity, FirmField, FirmFieldValue, FirmQueryResult, FirmSchema,
+    FirmSchemaField,
+};
 
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -198,6 +201,35 @@ impl FirmSession {
             Some(entities) => Ok(entities.iter().map(|e| FirmEntity::from(*e)).collect()),
             None => Ok(vec![]),
         }
+    }
+
+    /// Get the structured schema definition for an entity type.
+    pub fn get_schema(&self, entity_type: String) -> Result<Option<FirmSchema>, FirmError> {
+        let inner = self.inner.lock().map_err(|e| FirmError::Other {
+            message: e.to_string(),
+        })?;
+        let build = inner.build.as_ref().ok_or(FirmError::NotBuilt)?;
+        let et = EntityType::new(&entity_type);
+        Ok(build
+            .schemas
+            .iter()
+            .find(|s| s.entity_type == et)
+            .map(|s| {
+                let fields = s
+                    .ordered_fields()
+                    .iter()
+                    .map(|(field_id, field_schema)| FirmSchemaField {
+                        name: field_id.to_string(),
+                        field_type: field_schema.expected_type().to_string(),
+                        required: field_schema.is_required(),
+                        allowed_values: field_schema.allowed_values().cloned(),
+                    })
+                    .collect();
+                FirmSchema {
+                    entity_type: s.entity_type.to_string(),
+                    fields,
+                }
+            }))
     }
 
     /// Generate .firm DSL text for an entity.

--- a/firm_ffi/src/types.rs
+++ b/firm_ffi/src/types.rs
@@ -1,0 +1,201 @@
+//! UniFFI-compatible types that mirror firm_core's domain types.
+//!
+//! These are thin wrappers that avoid exposing Rust-specific types
+//! (Decimal, Currency, DateTime, PathBuf) across the FFI boundary.
+
+use std::path::PathBuf;
+
+use firm_core::{Entity, EntityId, EntityType, FieldId, FieldValue, ReferenceValue};
+
+/// A Firm entity with its type, ID, and fields.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FirmEntity {
+    /// Composite ID (e.g. "person.alice").
+    pub id: String,
+    /// Entity type (e.g. "person").
+    pub entity_type: String,
+    /// Ordered list of fields.
+    pub fields: Vec<FirmField>,
+}
+
+/// A named field on an entity.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FirmField {
+    pub name: String,
+    pub value: FirmFieldValue,
+}
+
+/// The value of an entity field.
+///
+/// Mirrors firm_core's `FieldValue` with FFI-safe types.
+/// `ReferenceValue` is flattened into two variants.
+/// `Currency` and `DateTime` use string representations.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum FirmFieldValue {
+    Boolean { value: bool },
+    String { value: String },
+    Integer { value: i64 },
+    Float { value: f64 },
+    /// Currency as decimal string + ISO 4217 code (e.g. "123.45", "USD").
+    Currency { amount: String, currency_code: String },
+    /// Reference to another entity (e.g. "person.alice").
+    EntityReference { entity_id: String },
+    /// Reference to a field on another entity.
+    FieldReference { entity_id: String, field_id: String },
+    /// Ordered list of values.
+    List { items: Vec<FirmFieldValue> },
+    /// ISO 8601 / RFC 3339 datetime string.
+    DateTime { value: String },
+    /// File path as string.
+    Path { value: String },
+    /// Enum variant name.
+    Enum { value: String },
+}
+
+/// Direction for traversing entity relationships.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum FirmDirection {
+    /// Entities this entity references.
+    Outgoing,
+    /// Entities that reference this entity.
+    Incoming,
+    /// Both directions.
+    Both,
+}
+
+/// The result of executing a query.
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum FirmQueryResult {
+    /// Matching entities.
+    Entities { entities: Vec<FirmEntity> },
+    /// Aggregation result as a display string (count, sum, average, etc.).
+    Aggregation { value: String },
+}
+
+// --- Conversions from firm_core types ---
+
+impl From<&Entity> for FirmEntity {
+    fn from(entity: &Entity) -> Self {
+        FirmEntity {
+            id: entity.id.to_string(),
+            entity_type: entity.entity_type.to_string(),
+            fields: entity
+                .fields
+                .iter()
+                .map(|(id, value)| FirmField {
+                    name: id.to_string(),
+                    value: FirmFieldValue::from(value),
+                })
+                .collect(),
+        }
+    }
+}
+
+// --- Conversions to firm_core types ---
+
+impl TryFrom<&FirmEntity> for Entity {
+    type Error = String;
+
+    fn try_from(firm: &FirmEntity) -> Result<Self, String> {
+        let entity_id = EntityId::new(&firm.id);
+        let entity_type = EntityType::new(&firm.entity_type);
+        let mut entity = Entity::new(entity_id, entity_type);
+
+        for field in &firm.fields {
+            let value = FieldValue::try_from(&field.value)?;
+            entity = entity.with_field(FieldId::new(&field.name), value);
+        }
+
+        Ok(entity)
+    }
+}
+
+impl TryFrom<&FirmFieldValue> for FieldValue {
+    type Error = String;
+
+    fn try_from(value: &FirmFieldValue) -> Result<Self, String> {
+        match value {
+            FirmFieldValue::Boolean { value } => Ok(FieldValue::Boolean(*value)),
+            FirmFieldValue::String { value } => Ok(FieldValue::String(value.clone())),
+            FirmFieldValue::Integer { value } => Ok(FieldValue::Integer(*value)),
+            FirmFieldValue::Float { value } => Ok(FieldValue::Float(*value)),
+            FirmFieldValue::Currency {
+                amount,
+                currency_code,
+            } => {
+                let decimal = rust_decimal::Decimal::from_str_exact(amount)
+                    .map_err(|e| format!("Invalid currency amount '{}': {}", amount, e))?;
+                let currency = iso_currency::Currency::from_code(currency_code)
+                    .ok_or_else(|| format!("Invalid currency code '{}'", currency_code))?;
+                Ok(FieldValue::Currency {
+                    amount: decimal,
+                    currency,
+                })
+            }
+            FirmFieldValue::EntityReference { entity_id } => Ok(FieldValue::Reference(
+                ReferenceValue::Entity(EntityId::new(entity_id)),
+            )),
+            FirmFieldValue::FieldReference {
+                entity_id,
+                field_id,
+            } => Ok(FieldValue::Reference(ReferenceValue::Field(
+                EntityId::new(entity_id),
+                FieldId::new(field_id),
+            ))),
+            FirmFieldValue::List { items } => {
+                let values: Result<Vec<FieldValue>, String> =
+                    items.iter().map(FieldValue::try_from).collect();
+                Ok(FieldValue::List(values?))
+            }
+            FirmFieldValue::DateTime { value } => {
+                let dt = chrono::DateTime::parse_from_rfc3339(value)
+                    .map_err(|e| format!("Invalid datetime '{}': {}", value, e))?;
+                Ok(FieldValue::DateTime(dt))
+            }
+            FirmFieldValue::Path { value } => Ok(FieldValue::Path(PathBuf::from(value))),
+            FirmFieldValue::Enum { value } => Ok(FieldValue::Enum(value.clone())),
+        }
+    }
+}
+
+// --- Conversions from firm_core types ---
+
+impl From<&FieldValue> for FirmFieldValue {
+    fn from(value: &FieldValue) -> Self {
+        match value {
+            FieldValue::Boolean(v) => FirmFieldValue::Boolean { value: *v },
+            FieldValue::String(v) => FirmFieldValue::String {
+                value: v.clone(),
+            },
+            FieldValue::Integer(v) => FirmFieldValue::Integer { value: *v },
+            FieldValue::Float(v) => FirmFieldValue::Float { value: *v },
+            FieldValue::Currency { amount, currency } => FirmFieldValue::Currency {
+                amount: amount.to_string(),
+                currency_code: currency.code().to_string(),
+            },
+            FieldValue::Reference(ReferenceValue::Entity(entity_id)) => {
+                FirmFieldValue::EntityReference {
+                    entity_id: entity_id.to_string(),
+                }
+            }
+            FieldValue::Reference(ReferenceValue::Field(entity_id, field_id)) => {
+                FirmFieldValue::FieldReference {
+                    entity_id: entity_id.to_string(),
+                    field_id: field_id.to_string(),
+                }
+            }
+            FieldValue::List(items) => FirmFieldValue::List {
+                items: items.iter().map(FirmFieldValue::from).collect(),
+            },
+            FieldValue::DateTime(dt) => FirmFieldValue::DateTime {
+                value: dt.to_rfc3339(),
+            },
+            FieldValue::Path(p) => FirmFieldValue::Path {
+                value: p.to_string_lossy().into_owned(),
+            },
+            FieldValue::Enum(v) => FirmFieldValue::Enum {
+                value: v.clone(),
+            },
+        }
+    }
+}

--- a/firm_ffi/src/types.rs
+++ b/firm_ffi/src/types.rs
@@ -72,6 +72,28 @@ pub enum FirmQueryResult {
     Aggregation { value: String },
 }
 
+/// A schema definition for an entity type.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FirmSchema {
+    /// Entity type name (e.g. "actor").
+    pub entity_type: String,
+    /// Fields in schema order.
+    pub fields: Vec<FirmSchemaField>,
+}
+
+/// A field definition within an entity schema.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct FirmSchemaField {
+    /// Field name (e.g. "name").
+    pub name: String,
+    /// Field type (e.g. "String", "Enum", "List").
+    pub field_type: String,
+    /// Whether the field is required.
+    pub required: bool,
+    /// Allowed values for enum fields, if constrained.
+    pub allowed_values: Option<Vec<String>>,
+}
+
 // --- Conversions from firm_core types ---
 
 impl From<&Entity> for FirmEntity {

--- a/firm_ffi/tests/session_tests.rs
+++ b/firm_ffi/tests/session_tests.rs
@@ -1,0 +1,428 @@
+use firm_ffi::{
+    FirmDirection, FirmEntity, FirmError, FirmField, FirmFieldValue, FirmQueryResult, FirmSession,
+};
+
+const TASK_SCHEMA: &str = r#"
+schema task {
+    field {
+        name = "title"
+        type = "string"
+        required = true
+    }
+
+    field {
+        name = "is_completed"
+        type = "boolean"
+        required = false
+    }
+
+    field {
+        name = "priority"
+        type = "integer"
+        required = false
+    }
+
+    field {
+        name = "assignee"
+        type = "reference"
+        required = false
+    }
+}
+"#;
+
+const PERSON_SCHEMA: &str = r#"
+schema person {
+    field {
+        name = "name"
+        type = "string"
+        required = true
+    }
+
+    field {
+        name = "email"
+        type = "string"
+        required = false
+    }
+}
+"#;
+
+const TASK_ENTITIES: &str = r#"
+task fix_bug {
+    title = "Fix the login bug"
+    is_completed = false
+    priority = 1
+}
+
+task write_docs {
+    title = "Write documentation"
+    is_completed = true
+    priority = 2
+}
+"#;
+
+const PERSON_ENTITIES: &str = r#"
+person alice {
+    name = "Alice"
+    email = "alice@example.com"
+}
+"#;
+
+const TASK_WITH_REF: &str = r#"
+task review_code {
+    title = "Review pull request"
+    is_completed = false
+    priority = 1
+    assignee = person.alice
+}
+"#;
+
+fn create_session_with_tasks() -> FirmSession {
+    let session = FirmSession::new();
+    session
+        .load_source(TASK_SCHEMA.to_string(), "schema.firm".to_string())
+        .unwrap();
+    session
+        .load_source(TASK_ENTITIES.to_string(), "tasks.firm".to_string())
+        .unwrap();
+    session.build().unwrap();
+    session
+}
+
+fn create_session_with_people_and_tasks() -> FirmSession {
+    let session = FirmSession::new();
+    session
+        .load_source(TASK_SCHEMA.to_string(), "schema/task.firm".to_string())
+        .unwrap();
+    session
+        .load_source(PERSON_SCHEMA.to_string(), "schema/person.firm".to_string())
+        .unwrap();
+    session
+        .load_source(PERSON_ENTITIES.to_string(), "people.firm".to_string())
+        .unwrap();
+    session
+        .load_source(TASK_WITH_REF.to_string(), "tasks.firm".to_string())
+        .unwrap();
+    session.build().unwrap();
+    session
+}
+
+/// Helper to extract entities from a query result.
+fn unwrap_entities(result: FirmQueryResult) -> Vec<FirmEntity> {
+    match result {
+        FirmQueryResult::Entities { entities } => entities,
+        FirmQueryResult::Aggregation { value } => {
+            panic!("Expected entities, got aggregation: {}", value)
+        }
+    }
+}
+
+/// Helper to find a field value by name on an entity.
+fn get_field<'a>(entity: &'a FirmEntity, name: &str) -> Option<&'a FirmFieldValue> {
+    entity
+        .fields
+        .iter()
+        .find(|f| f.name == name)
+        .map(|f| &f.value)
+}
+
+#[test]
+fn test_create_and_build_empty() {
+    let session = FirmSession::new();
+    session.build().unwrap();
+
+    let schemas = session.list_schemas().unwrap();
+    assert!(schemas.is_empty());
+}
+
+#[test]
+fn test_load_and_build() {
+    let session = create_session_with_tasks();
+
+    let entities = session.list_entities("task".to_string()).unwrap();
+    assert_eq!(entities.len(), 2);
+    assert!(entities.iter().any(|id| id.contains("fix_bug")));
+    assert!(entities.iter().any(|id| id.contains("write_docs")));
+}
+
+#[test]
+fn test_query() {
+    let session = create_session_with_tasks();
+
+    let result = session
+        .query("from task | where is_completed == false".to_string())
+        .unwrap();
+    let entities = unwrap_entities(result);
+    assert_eq!(entities.len(), 1);
+    assert!(entities[0].id.contains("fix_bug"));
+}
+
+#[test]
+fn test_query_returns_typed_fields() {
+    let session = create_session_with_tasks();
+
+    let result = session
+        .query("from task | where priority == 1".to_string())
+        .unwrap();
+    let entities = unwrap_entities(result);
+    assert_eq!(entities.len(), 1);
+
+    let entity = &entities[0];
+    assert_eq!(entity.entity_type, "task");
+
+    // Verify typed field values
+    match get_field(entity, "title") {
+        Some(FirmFieldValue::String { value }) => {
+            assert_eq!(value, "Fix the login bug");
+        }
+        other => panic!("Expected String field, got {:?}", other),
+    }
+
+    match get_field(entity, "is_completed") {
+        Some(FirmFieldValue::Boolean { value }) => {
+            assert!(!value);
+        }
+        other => panic!("Expected Boolean field, got {:?}", other),
+    }
+
+    match get_field(entity, "priority") {
+        Some(FirmFieldValue::Integer { value }) => {
+            assert_eq!(*value, 1);
+        }
+        other => panic!("Expected Integer field, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_query_aggregation() {
+    let session = create_session_with_tasks();
+
+    let result = session
+        .query("from task | count".to_string())
+        .unwrap();
+    match result {
+        FirmQueryResult::Aggregation { value } => {
+            assert_eq!(value, "2");
+        }
+        FirmQueryResult::Entities { .. } => panic!("Expected aggregation"),
+    }
+}
+
+#[test]
+fn test_get_entity() {
+    let session = create_session_with_tasks();
+
+    let entity = session
+        .get_entity("task".to_string(), "fix_bug".to_string())
+        .unwrap();
+    assert!(entity.is_some());
+
+    let entity = entity.unwrap();
+    assert!(entity.id.contains("fix_bug"));
+    assert_eq!(entity.entity_type, "task");
+
+    match get_field(&entity, "title") {
+        Some(FirmFieldValue::String { value }) => {
+            assert_eq!(value, "Fix the login bug");
+        }
+        other => panic!("Expected String field, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_get_entity_not_found() {
+    let session = create_session_with_tasks();
+
+    let result = session
+        .get_entity("task".to_string(), "nonexistent".to_string())
+        .unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_list_entities() {
+    let session = create_session_with_tasks();
+
+    let entities = session.list_entities("task".to_string()).unwrap();
+    assert_eq!(entities.len(), 2);
+}
+
+#[test]
+fn test_list_schemas() {
+    let session = create_session_with_tasks();
+
+    let schemas = session.list_schemas().unwrap();
+    assert_eq!(schemas.len(), 1);
+    assert!(schemas.contains(&"task".to_string()));
+}
+
+#[test]
+fn test_generate_entity_dsl() {
+    let session = create_session_with_tasks();
+
+    let entity = FirmEntity {
+        id: "task.new_task".to_string(),
+        entity_type: "task".to_string(),
+        fields: vec![
+            FirmField {
+                name: "title".to_string(),
+                value: FirmFieldValue::String {
+                    value: "New task".to_string(),
+                },
+            },
+            FirmField {
+                name: "is_completed".to_string(),
+                value: FirmFieldValue::Boolean { value: false },
+            },
+            FirmField {
+                name: "priority".to_string(),
+                value: FirmFieldValue::Integer { value: 3 },
+            },
+        ],
+    };
+
+    let dsl = session.generate_entity_dsl(entity).unwrap();
+
+    assert!(dsl.contains("task new_task"));
+    assert!(dsl.contains("\"New task\""));
+    assert!(dsl.contains("false"));
+    assert!(dsl.contains("3"));
+}
+
+#[test]
+fn test_find_entity_source() {
+    let session = create_session_with_tasks();
+
+    let path = session
+        .find_entity_source("task".to_string(), "fix_bug".to_string())
+        .unwrap();
+    assert!(path.is_some());
+    assert_eq!(path.unwrap(), "tasks.firm");
+}
+
+#[test]
+fn test_find_entity_source_not_found() {
+    let session = create_session_with_tasks();
+
+    let path = session
+        .find_entity_source("task".to_string(), "nonexistent".to_string())
+        .unwrap();
+    assert!(path.is_none());
+}
+
+#[test]
+fn test_get_source() {
+    let session = FirmSession::new();
+    session
+        .load_source(TASK_SCHEMA.to_string(), "schema.firm".to_string())
+        .unwrap();
+
+    let source = session.get_source("schema.firm".to_string()).unwrap();
+    assert!(source.is_some());
+    assert!(source.unwrap().contains("schema task"));
+}
+
+#[test]
+fn test_get_source_not_found() {
+    let session = FirmSession::new();
+
+    let source = session.get_source("nonexistent.firm".to_string()).unwrap();
+    assert!(source.is_none());
+}
+
+#[test]
+fn test_get_related() {
+    let session = create_session_with_people_and_tasks();
+
+    let related = session
+        .get_related("person".to_string(), "alice".to_string(), FirmDirection::Both)
+        .unwrap();
+    assert_eq!(related.len(), 1);
+    assert!(related[0].id.contains("review_code"));
+}
+
+#[test]
+fn test_get_related_entity_reference_field() {
+    let session = create_session_with_people_and_tasks();
+
+    let entity = session
+        .get_entity("task".to_string(), "review_code".to_string())
+        .unwrap()
+        .unwrap();
+
+    match get_field(&entity, "assignee") {
+        Some(FirmFieldValue::EntityReference { entity_id }) => {
+            assert!(entity_id.contains("alice"));
+        }
+        other => panic!("Expected EntityReference, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_load_invalid_source() {
+    let session = FirmSession::new();
+
+    session
+        .load_source(TASK_SCHEMA.to_string(), "schema.firm".to_string())
+        .unwrap();
+    session
+        .load_source(
+            "task broken {\n}\n".to_string(),
+            "broken.firm".to_string(),
+        )
+        .unwrap();
+
+    let result = session.build();
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        FirmError::BuildError { .. } => {}
+        other => panic!("Expected BuildError, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_query_before_build() {
+    let session = FirmSession::new();
+    session
+        .load_source(TASK_SCHEMA.to_string(), "schema.firm".to_string())
+        .unwrap();
+
+    let result = session.query("from task".to_string());
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        FirmError::NotBuilt => {}
+        other => panic!("Expected NotBuilt, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_build_invalidates_on_new_source() {
+    let session = FirmSession::new();
+    session
+        .load_source(TASK_SCHEMA.to_string(), "schema.firm".to_string())
+        .unwrap();
+    session
+        .load_source(TASK_ENTITIES.to_string(), "tasks.firm".to_string())
+        .unwrap();
+    session.build().unwrap();
+
+    // Loading new source should invalidate the build
+    session
+        .load_source(
+            "task extra { title = \"Extra\" }\n".to_string(),
+            "extra.firm".to_string(),
+        )
+        .unwrap();
+
+    // Query should fail since build is invalidated
+    let result = session.query("from task".to_string());
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        FirmError::NotBuilt => {}
+        other => panic!("Expected NotBuilt, got {:?}", other),
+    }
+
+    // Rebuild should work
+    session.build().unwrap();
+    let entities = session.list_entities("task".to_string()).unwrap();
+    assert_eq!(entities.len(), 3);
+}

--- a/firm_ffi/uniffi-bindgen.rs
+++ b/firm_ffi/uniffi-bindgen.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/firm_lang/src/workspace/build.rs
+++ b/firm_lang/src/workspace/build.rs
@@ -78,10 +78,11 @@ impl Workspace {
 
                 // Validate the entity against its schema
                 if let Err(validation_errors) = schema.validate(&entity) {
-                    let error_msg = format!(
-                        "Entity '{}' failed validation: {:?}",
-                        entity.id, validation_errors
-                    );
+                    let error_msg = validation_errors
+                        .iter()
+                        .map(|e| e.message.as_str())
+                        .collect::<Vec<_>>()
+                        .join("; ");
                     return Err(WorkspaceError::ValidationError(path.clone(), error_msg));
                 }
 

--- a/firm_lang/src/workspace/io.rs
+++ b/firm_lang/src/workspace/io.rs
@@ -56,6 +56,21 @@ impl Workspace {
         Ok(())
     }
 
+    /// Load firm source from a string with a virtual path.
+    ///
+    /// The path is used for error reporting and entity/schema lookup,
+    /// but does not need to correspond to an actual file on disk.
+    pub fn load_string(
+        &mut self,
+        content: String,
+        path: PathBuf,
+    ) -> Result<(), WorkspaceError> {
+        let parsed = parse_source(content, Some(path.clone()))
+            .map_err(|err| WorkspaceError::ParseError(path.clone(), err.to_string()))?;
+        self.files.insert(path, WorkspaceFile::new(parsed));
+        Ok(())
+    }
+
     /// Returns true if a path has the .firm extension
     fn is_firm_file(&self, path: &Path) -> bool {
         path.extension()

--- a/firm_lang/src/workspace/mod.rs
+++ b/firm_lang/src/workspace/mod.rs
@@ -58,6 +58,11 @@ impl Workspace {
         None
     }
 
+    /// Gets the source text for a loaded file path.
+    pub fn get_source(&self, path: &PathBuf) -> Option<&str> {
+        self.files.get(path).map(|f| f.parsed.source.as_str())
+    }
+
     /// Finds the source file path for a schema by its name.
     ///
     /// This performs a linear search through all parsed files in the workspace,

--- a/firm_lang/src/workspace/workspace_errors.rs
+++ b/firm_lang/src/workspace/workspace_errors.rs
@@ -2,8 +2,6 @@ use std::{fmt, io, path::PathBuf};
 
 use firm_core::EntityType;
 
-use crate::defaults;
-
 /// Defines the errors you might encounter using a workspace.
 #[derive(Debug)]
 pub enum WorkspaceError {
@@ -32,31 +30,8 @@ impl fmt::Display for WorkspaceError {
                 error
             ),
             WorkspaceError::MissingSchemaError(path_buf, entity_type) => {
-                let is_default_schema = is_default_schema_type(entity_type);
-
-                if is_default_schema {
-                    write!(
-                        f,
-                        "No schema found for entity type '{}' in {}\n\nRun 'firm init' to create default schemas, or define your own schema in your workspace.",
-                        entity_type,
-                        path_buf.display()
-                    )
-                } else {
-                    write!(
-                        f,
-                        "No schema found for entity type '{}' in {}\n\nDefine a schema for this type in your workspace.",
-                        entity_type,
-                        path_buf.display()
-                    )
-                }
+                write!(f, "No schema found for entity type '{}' in {}", entity_type, path_buf.display())
             }
         }
     }
-}
-
-/// Check if an entity type matches one of the default schemas.
-fn is_default_schema_type(entity_type: &EntityType) -> bool {
-    defaults::all_default_schemas()
-        .iter()
-        .any(|schema| &schema.entity_type == entity_type)
 }


### PR DESCRIPTION
I'm working on a project where embedding firm as a "knowledge layer" would be beneficial.

So I've added a new create for FFI bindings with UniFFI, allowing bindings to be generated for iOS, and potentially other targets in the future.

This is the plumbing needed to use Firm as a native library embedded in other (non-rust) apps.