### PR TITLE
feat(workspace): add .firmignore support for ignoring files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +352,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -529,6 +558,7 @@ dependencies = [
  "chrono",
  "env_logger",
  "firm_core",
+ "ignore",
  "iso_currency",
  "log",
  "path-clean",
@@ -730,6 +760,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +843,22 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -1392,6 +1451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1974,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,6 +2074,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docs/src/getting-started/workspace.md
+++ b/docs/src/getting-started/workspace.md
@@ -34,6 +34,24 @@ You can organize your `.firm` files however you like:
 
 Firm will discover and process all `.firm` files in your workspace directory recursively.
 
+## Ignoring files
+
+You can exclude specific directories or files from being processed by creating a `.firmignore` file in your workspace root. This uses the same pattern syntax as `.gitignore`.
+
+For example, to ignore git worktrees stored in `.worktrees/`:
+
+```gitignore
+# .firmignore
+**/.worktrees/
+```
+
+Common use cases:
+- Exclude git worktrees (e.g., `.worktrees/`, `.git/worktrees/`)
+- Exclude backup directories
+- Exclude specific files you don't want in your graph
+
+If no `.firmignore` exists, Firm will fall back to reading `.gitignore` patterns. If neither file exists, all `.firm` files in the workspace are loaded.
+
 ## Version control
 
 Since your workspace is just plain text files, you can (and should!) put it in version control:

--- a/firm_lang/Cargo.toml
+++ b/firm_lang/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version = "0.4", features = ["serde"] }
 path-clean = "1.0.1"
 pest = "2.7"
 pest_derive = "2.7"
+ignore = "0.4"
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/firm_lang/src/workspace/io.rs
+++ b/firm_lang/src/workspace/io.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ignore::WalkBuilder;
+use ignore::{overrides::OverrideBuilder, WalkBuilder};
 
 use crate::{parser::dsl::parse_source, workspace::WorkspaceFile};
 
@@ -31,22 +31,33 @@ impl Workspace {
     }
 
     pub fn load_directory(&mut self, directory_path: &PathBuf) -> Result<(), WorkspaceError> {
+        // 1. Always load schemas from .firm/schemas/ explicitly - never subject to ignore rules
+        let schemas_dir = directory_path.join(".firm").join("schemas");
+        if schemas_dir.is_dir() {
+            for entry in fs::read_dir(&schemas_dir).map_err(WorkspaceError::IoError)? {
+                let entry = entry.map_err(WorkspaceError::IoError)?;
+                let path = entry.path();
+                if path.is_file() && self.is_firm_file(&path) {
+                    self.load_file(&path, directory_path)?;
+                }
+            }
+        }
+
+        // 2. Walk the rest of the workspace for entity files, respecting .firmignore / .gitignore
         let ignore_path = directory_path.join(".firmignore");
         let gitignore_path = directory_path.join(".gitignore");
 
         let mut binding = WalkBuilder::new(directory_path);
         let walker_builder = binding
-            .hidden(true)
+            .hidden(true)  // skip hidden dirs (like .firm, .citadel) during entity walk
             .require_git(false)
-            .filter_entry(move |entry| {
+            .filter_entry(|entry| {
                 let path = entry.path();
-
                 if path.is_file() {
                     return path
                         .extension()
                         .map_or(false, |ext| ext == FIRM_FILE_EXTENSION);
                 }
-
                 true
             });
 
@@ -56,9 +67,7 @@ impl Workspace {
             let _ = walker_builder.git_ignore(true);
         }
 
-        let walker = walker_builder.build();
-
-        for result in walker {
+        for result in walker_builder.build() {
             match result {
                 Ok(entry) => {
                     let path = entry.path().to_path_buf();

--- a/firm_lang/src/workspace/io.rs
+++ b/firm_lang/src/workspace/io.rs
@@ -1,4 +1,9 @@
-use std::{fs, path::{Path, PathBuf}};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use ignore::WalkBuilder;
 
 use crate::{parser::dsl::parse_source, workspace::WorkspaceFile};
 
@@ -7,21 +12,17 @@ use super::{Workspace, WorkspaceError};
 const FIRM_FILE_EXTENSION: &str = "firm";
 
 impl Workspace {
-    /// Load a single firm source file.
     pub fn load_file(
         &mut self,
         path: &PathBuf,
         workspace_path: &PathBuf,
     ) -> Result<(), WorkspaceError> {
-        // Read the source text
         let text = fs::read_to_string(path).map_err(WorkspaceError::IoError)?;
 
-        // Make the source path relative to the workspace
         let relative_path = path
             .strip_prefix(workspace_path)
             .map_err(|err| WorkspaceError::ParseError(path.clone(), err.to_string()))?;
 
-        // Parse the source text
         let parsed = parse_source(text.clone(), Some(relative_path.to_path_buf()))
             .map_err(|err| WorkspaceError::ParseError(path.clone(), err.to_string()))?;
 
@@ -29,34 +30,52 @@ impl Workspace {
         Ok(())
     }
 
-    /// Loads all firm files in a directory and its subdirectories.
     pub fn load_directory(&mut self, directory_path: &PathBuf) -> Result<(), WorkspaceError> {
-        self.load_directory_recursive(directory_path, directory_path)
-    }
+        let ignore_path = directory_path.join(".firmignore");
+        let gitignore_path = directory_path.join(".gitignore");
 
-    /// Load all firm files in a directory recursively.
-    fn load_directory_recursive(
-        &mut self,
-        directory_path: &PathBuf,
-        root_directory_path: &PathBuf,
-    ) -> Result<(), WorkspaceError> {
-        let entries = fs::read_dir(directory_path).map_err(WorkspaceError::IoError)?;
+        let mut binding = WalkBuilder::new(directory_path);
+        let walker_builder = binding
+            .hidden(true)
+            .require_git(false)
+            .filter_entry(move |entry| {
+                let path = entry.path();
 
-        for entry in entries {
-            let entry = entry.map_err(WorkspaceError::IoError)?;
-            let path = entry.path();
+                if path.is_file() {
+                    return path
+                        .extension()
+                        .map_or(false, |ext| ext == FIRM_FILE_EXTENSION);
+                }
 
-            if path.is_dir() {
-                self.load_directory_recursive(&path, root_directory_path)?;
-            } else if path.is_file() && self.is_firm_file(&path) {
-                self.load_file(&path, root_directory_path)?;
+                true
+            });
+
+        if ignore_path.exists() {
+            let _ = walker_builder.add_ignore(&ignore_path);
+        } else if gitignore_path.exists() {
+            let _ = walker_builder.git_ignore(true);
+        }
+
+        let walker = walker_builder.build();
+
+        for result in walker {
+            match result {
+                Ok(entry) => {
+                    let path = entry.path().to_path_buf();
+                    if self.is_firm_file(&path) {
+                        self.load_file(&path, directory_path)?;
+                    }
+                }
+                Err(e) => {
+                    let io_err = std::io::Error::other(e.to_string());
+                    return Err(WorkspaceError::IoError(io_err));
+                }
             }
         }
 
         Ok(())
     }
 
-    /// Returns true if a path has the .firm extension
     fn is_firm_file(&self, path: &Path) -> bool {
         path.extension()
             .and_then(|ext| ext.to_str())

--- a/firm_lang/tests/workspace_tests.rs
+++ b/firm_lang/tests/workspace_tests.rs
@@ -53,6 +53,117 @@ mod tests {
     }
 
     #[test]
+    fn test_load_directory_with_firmignore() {
+        use std::fs;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        let main_file = temp_dir.path().join("main.firm");
+        fs::write(&main_file, "person john { name = \"John\" }").expect("Write main file");
+
+        let ignored_dir = temp_dir.path().join("ignored_dir");
+        fs::create_dir(&ignored_dir).expect("Create ignored dir");
+        let ignored_file = ignored_dir.join("data.firm");
+        fs::write(&ignored_file, "person jane { name = \"Jane\" }").expect("Write ignored file");
+
+        let firmignore_path = temp_dir.path().join(".firmignore");
+        fs::write(&firmignore_path, "ignored_dir/\n").expect("Write firmignore");
+
+        let mut workspace = Workspace::new();
+        let result = workspace.load_directory(&temp_dir.path().to_path_buf());
+        assert!(result.is_ok(), "Should load directory successfully");
+
+        assert_eq!(
+            workspace.num_files(),
+            1,
+            "Should only load main.firm, not ignored_dir/data.firm"
+        );
+    }
+
+    #[test]
+    fn test_load_directory_with_gitignore_fallback() {
+        use std::fs;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        let main_file = temp_dir.path().join("main.firm");
+        fs::write(&main_file, "person john { name = \"John\" }").expect("Write main file");
+
+        let ignored_dir = temp_dir.path().join("node_modules");
+        fs::create_dir(&ignored_dir).expect("Create node_modules dir");
+        let ignored_file = ignored_dir.join("data.firm");
+        fs::write(&ignored_file, "person jane { name = \"Jane\" }").expect("Write ignored file");
+
+        let gitignore_path = temp_dir.path().join(".gitignore");
+        fs::write(&gitignore_path, "node_modules/\n").expect("Write gitignore");
+
+        let mut workspace = Workspace::new();
+        let result = workspace.load_directory(&temp_dir.path().to_path_buf());
+        assert!(result.is_ok(), "Should load directory successfully");
+
+        assert_eq!(
+            workspace.num_files(),
+            1,
+            "Should only load main.firm, not node_modules/data.firm"
+        );
+    }
+
+    #[test]
+    fn test_load_directory_no_ignore_files() {
+        use std::fs;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        let main_file = temp_dir.path().join("main.firm");
+        fs::write(&main_file, "person john { name = \"John\" }").expect("Write main file");
+
+        let subdir = temp_dir.path().join("subdir");
+        fs::create_dir(&subdir).expect("Create subdir");
+        let subdir_file = subdir.join("data.firm");
+        fs::write(&subdir_file, "person jane { name = \"Jane\" }").expect("Write subdir file");
+
+        let mut workspace = Workspace::new();
+        let result = workspace.load_directory(&temp_dir.path().to_path_buf());
+        assert!(result.is_ok(), "Should load directory successfully");
+
+        assert_eq!(
+            workspace.num_files(),
+            2,
+            "Should load both files when no ignore files exist"
+        );
+    }
+
+    #[test]
+    fn test_load_directory_respects_firmignore_glob_patterns() {
+        use std::fs;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        let main_file = temp_dir.path().join("main.firm");
+        fs::write(&main_file, "person john { name = \"John\" }").expect("Write main file");
+
+        let dot_citadel = temp_dir.path().join(".citadel");
+        fs::create_dir(&dot_citadel).expect("Create .citadel dir");
+        let worktrees = dot_citadel.join("worktrees");
+        fs::create_dir(&worktrees).expect("Create worktrees dir");
+        let ignored_file = worktrees.join("data.firm");
+        fs::write(&ignored_file, "person jane { name = \"Jane\" }").expect("Write ignored file");
+
+        let firmignore_path = temp_dir.path().join(".firmignore");
+        fs::write(&firmignore_path, "**/.citadel/\n").expect("Write firmignore");
+
+        let mut workspace = Workspace::new();
+        let result = workspace.load_directory(&temp_dir.path().to_path_buf());
+        assert!(result.is_ok(), "Should load directory successfully");
+
+        assert_eq!(
+            workspace.num_files(),
+            1,
+            "Should only load main.firm, not .citadel/worktrees/data.firm"
+        );
+    }
+
+    #[test]
     fn test_load_empty_directory() {
         let temp_dir = TempDir::new().unwrap();
         let temp_path = temp_dir.path();


### PR DESCRIPTION
- Add ignore crate dependency for gitignore-style pattern matching
- Refactor load_directory to use WalkBuilder from ignore crate
- Support .firmignore file, with fallback to .gitignore, then no filtering
- Add tests for ignore file logic
- Document feature in workspace.md